### PR TITLE
add purge option for records

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ IN/A/server.example.com:
   rrdata:
   - 192.168.0.1
   ttl: 86400
+  purge: false
   zone: example.com
   server: ns.example.com
   keyname: rndc-key

--- a/lib/puppet/provider/dns_rr/nsupdate.rb
+++ b/lib/puppet/provider/dns_rr/nsupdate.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:dns_rr).provide(:nsupdate) do
   def flush
     return if @properties.empty?
     update do |file|
-      destructo(file)
+      destructo(file) if resource[:purge]
       accio(file)
     end
   end

--- a/lib/puppet/type/dns_rr.rb
+++ b/lib/puppet/type/dns_rr.rb
@@ -39,6 +39,11 @@ Puppet::Type.newtype(:dns_rr) do
     end
   end
 
+  newparam(:purge) do
+    desc 'purge rrdata'
+    defaultto true
+  end
+
   newparam(:zone) do
     desc 'The zone to update'
   end


### PR DESCRIPTION
Add an optional purge parameter. Currently records are purged. With this parameter the default behaviour can be disabled in order to support SRV Style records from multiple (agent)sources. For backward compatibility the default is to still purge the records.
