### PR TITLE
add support for srv records like _ldap._tcp.example.com

### DIFF
--- a/lib/puppet/type/dns_rr.rb
+++ b/lib/puppet/type/dns_rr.rb
@@ -7,7 +7,7 @@ Puppet::Type.newtype(:dns_rr) do
     desc "Class/Type/Name for the resource record"
 
     validate do |value|
-      if (value =~ /^([A-Z]+)\/([A-Z]+)\/[a-zA-Z0-9.-]+$/)
+      if (value =~ /^([A-Z]+)\/([A-Z]+)\/[a-zA-Z0-9.\-_]+$/)
         rrclass = $1
         if ( !%w(IN CH HS).include? rrclass )
           raise ArgumentError, "Invalid resource record class: %s" % rrdata


### PR DESCRIPTION
The current input validation prevents SRV Style records due to filtered underscores in the regex.
